### PR TITLE
chore(ci): add create-release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,12 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-release:
+    uses: MCEngine-Extension/gradle/.github/workflows/create-release-extension-with-testing-jar.yml@master
+    with:
+      repo-name: ${{ github.repository }}
+    secrets:
+      USER_GITHUB_TOKEN: ${{ secrets.USER_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to create releases via `MCEngine-Action/gradle`.

It was created automatically across the org.